### PR TITLE
Fix Possible Null Pointer De-reference.

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -1496,14 +1496,14 @@ static WBXMLError wbxml_fill_header(WBXMLEncoder *encoder, WBXMLBuffer *header)
     WB_ULONG public_id = 0, public_id_index = 0, strstbl_len = 0;
     WB_BOOL pi_in_strtbl = FALSE;
     WBXMLError ret = WBXML_OK;
-
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLStringTableElement *elt = NULL;
+    WB_BOOL added = FALSE;
+#endif /* WBXML_ENCODER_USE_STRTBL */
     if ((encoder == NULL) || (encoder->lang == NULL) || (encoder->lang->publicID == NULL) || (header == NULL))
         return WBXML_ERROR_BAD_PARAMETER;
     
 #if defined( WBXML_ENCODER_USE_STRTBL )
-    WBXMLStringTableElement *elt = NULL;
-    WB_BOOL added = FALSE;
-
     strstbl_len = encoder->strstbl_len;
 #endif /* WBXML_ENCODER_USE_STRTBL */
 


### PR DESCRIPTION
Inside macro :
# if defined( WBXML_ENCODER_USE_STRTBL ), encoder is dereferenced without Null check as below :

```
strstbl_len = encoder->strstbl_len;
```

So, this may cause crash. Hence moved the Null check condition at appropriate place.
