### PR TITLE
Fix leaking resource.

### DIFF
--- a/src/wbxml_tree_clb_xml.c
+++ b/src/wbxml_tree_clb_xml.c
@@ -312,7 +312,14 @@ void wbxml_tree_clb_xml_end_element(void           *ctx,
 				break;
 			default:
 				tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+				wbxml_buffer_destroy(embed_doc);
 				return;
+		}
+		
+		if (lang == NULL) {
+			tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+			wbxml_buffer_destroy(embed_doc);
+			return;
 		}
 
 		/* DOCTYPE in reverse order */


### PR DESCRIPTION
Default case of switch(tree_ctx->tree->lang->langID) does not destroy embed_doc. Corrected that. Also if Null check for lang is missing, so added as wbxml_tables_get_table may return NULL.
