### PR TITLE
Null Pointer check.

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -3823,6 +3823,13 @@ static WBXMLError wbxml_strtbl_check_references(WBXMLEncoder *encoder, WBXMLList
         for (j = 0; j < wbxml_list_len(referenced); j++)
         {
             ref = (WBXMLStringTableElement *) wbxml_list_get(referenced, j);
+            if (ref == NULL) 
+            {
+            	if (!stat_buff)
+                    wbxml_buffer_destroy(string);
+                string = NULL;
+                return WBXML_ERROR_INTERNAL;
+            }
 
             if (wbxml_buffer_compare(ref->string, string) == 0)
             {


### PR DESCRIPTION
ref = (WBXMLStringTableElement *) wbxml_list_get(referenced, j);

In reference to  : https://github.com/libwbxml/libwbxml/commit/9f7fb3008fc0156e8bfd12c8e4cb41c70e315c68

wbxml_get_list can return NULL. Hence good to do Null check before dereferencing.
