### PR TITLE
Fixed leaking resource "ext"

### DIFF
--- a/src/wbxml_parser.c
+++ b/src/wbxml_parser.c
@@ -1697,6 +1697,7 @@ static WBXMLError parse_extension(WBXMLParser *parser, WBXMLTokenType code_space
     }
     else {
         if ((*result = wbxml_buffer_create(ext, len, len)) == NULL) {
+            wbxml_free(ext);
             return WBXML_ERROR_NOT_ENOUGH_MEMORY;
         }
 


### PR DESCRIPTION
wbxml_free(ext); missed at one of return place.
This may cause memory leak.
