### PR TITLE
Fixed leaking resource "var_value"

### DIFF
--- a/src/wbxml_parser.c
+++ b/src/wbxml_parser.c
@@ -1587,6 +1587,7 @@ static WBXMLError parse_extension(WBXMLParser *parser, WBXMLTokenType code_space
                                        WBXML_STRLEN(escape) +
                                        WBXML_STRLEN(var_end) + 1);
         if (ext == NULL) {
+            wbxml_buffer_destroy(var_value);
             return WBXML_ERROR_NOT_ENOUGH_MEMORY;
         }
     


### PR DESCRIPTION
memory allocated to var_value is not freed at one of return places. It may cause memory leak.
