### PR TITLE
Fix Possible Null Pointer De-reference.

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -1139,6 +1139,7 @@ static WBXMLError parse_element(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_B
 {
     WB_ULONG i = 0;
     WBXMLError ret = WBXML_OK;
+    WBXMLAttribute *attr = NULL;
 
     WBXML_DEBUG((WBXML_ENCODER, "Element: <%s>", wbxml_tag_get_xml_name(node->name)));
 
@@ -1167,7 +1168,8 @@ static WBXMLError parse_element(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_B
     {
         for (i = 0; i < wbxml_list_len(node->attrs); i++) {
             /* Parse: Attribute */
-            if ((ret = parse_attribute(encoder, wbxml_list_get(node->attrs, i))) != WBXML_OK)
+            attr = wbxml_list_get(node->attrs, i);
+            if ((attr) && (ret = parse_attribute(encoder, attr)) != WBXML_OK)
                 return ret;
         }
     }


### PR DESCRIPTION
In reference to https://github.com/libwbxml/libwbxml/commit/9f7fb3008fc0156e8bfd12c8e4cb41c70e315c68.
wbxml_list_get can return NULL.
In that case parse_attribute will crash as it dereference result of wbxml_list_get.
So this fix is applied.
