### PR TITLE
Fix Null Pointer Dereference.

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -3723,6 +3723,8 @@ static WBXMLError wbxml_strtbl_collect_words(WBXMLList *elements, WBXMLList **re
     for (i = 0; i < wbxml_list_len(elements); i++)
     {
         elt = (WBXMLStringTableElement *) wbxml_list_get(elements, i);
+        if (elt == NULL)
+            return WBXML_ERROR_INTERNAL;
 
         if (list == NULL) {
             if ((list = wbxml_buffer_split_words(elt->string)) == NULL) {


### PR DESCRIPTION
In reference to : https://github.com/libwbxml/libwbxml/commit/9f7fb3008fc0156e8bfd12c8e4cb41c70e315c68
wbxml_list_get can return NULL.
returning in case elt is NULL.
