### PR TITLE
Null Pointer check for xml_len.

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -3994,7 +3994,8 @@ static WBXMLError xml_build_result(WBXMLEncoder *encoder, WB_UTINY **xml, WB_ULO
     WBXMLError   ret    = WBXML_OK;
     
     /* Init */
-    *xml_len = 0;
+    if (xml_len != NULL)
+        *xml_len = 0;
     
     if (encoder->flow_mode == TRUE) {
         /* Header already built */


### PR DESCRIPTION
Cannot dereference xml_len before Null check.
Use same as done on line no : 4043
