### PR TITLE
Null check done for correct pointer.

### DIFF
--- a/src/wbxml_conv.c
+++ b/src/wbxml_conv.c
@@ -209,7 +209,7 @@ WBXML_DECLARE(void) wbxml_conv_wbxml2xml_destroy(WBXMLConvWBXML2XML *conv)
 WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_create(WBXMLConvXML2WBXML **conv)
 {
     *conv = (WBXMLConvXML2WBXML *) wbxml_malloc(sizeof(WBXMLConvXML2WBXML));
-    if (conv == NULL) {
+    if (*conv == NULL) {
         return WBXML_ERROR_NOT_ENOUGH_MEMORY;
     }
 


### PR DESCRIPTION
if (conv == NULL) means conv can be NULL, hence dereferencing it at line no 67 is illegal.
Since memory is allocated to *conv, so Null check should be done on *conv instead of conv.
If want Null check on conv also, it can be done before malloc.
