### PR TITLE
Use CHECK_LDFLAGS if pkg-config is available

### DIFF
--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -15,7 +15,12 @@ FOREACH( SRC_FILE lists buffers base64 charset conv encoder_internals errors par
     ADD_EXECUTABLE(test_wbxml_${SRC_FILE} test_wbxml_${SRC_FILE}.c api_test.c)
 
     TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} wbxml2)
+
+    IF( PKG_CONFIG_FOUND )
+    TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} ${CHECK_LDFLAGS})
+    ELSE ( PKG_CONFIG_FOUND )
     TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} ${CHECK_LIBRARIES})
+    ENDIF ( PKG_CONFIG_FOUND )
 
     ADD_TEST(api_private_wbxml_${SRC_FILE} ${CMAKE_CURRENT_BINARY_DIR}/test_wbxml_${SRC_FILE})
 


### PR DESCRIPTION
Use the ldflags provided by pkg-config if pkg-config is available. Without this it fails to build on my Ubuntu 14.04 machine with the following error because -pthread is missing:

```
Linking C executable test_wbxml_base64
cd /home/jeroen/github/libwbxml/build/test/api && /usr/bin/cmake -E cmake_link_script CMakeFiles/test_wbxml_base64.dir/link.txt --verbose=1
/usr/bin/cc      CMakeFiles/test_wbxml_base64.dir/test_wbxml_base64.o CMakeFiles/test_wbxml_base64.dir/api_test.o  -o test_wbxml_base64 -rdynamic ../../src/libwbxml2.so.1.0.5 -lcheck_pic -lrt -lm -lexpat -Wl,-rpath,/home/jeroen/github/libwbxml/build/src 
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libcheck_pic.a(check_pack.o): undefined reference to symbol '__pthread_unregister_cancel@@GLIBC_2.3.3'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```