### PR TITLE
Fix memory leak in "list"

### DIFF
--- a/src/wbxml_encoder.c
+++ b/src/wbxml_encoder.c
@@ -3760,6 +3760,7 @@ static WBXMLError wbxml_strtbl_collect_words(WBXMLList *elements, WBXMLList **re
             /* There is a bug inside the wbxml strtbl implementation.
                wbxml_list must be used in a wrong way.
              */
+            wbxml_list_destroy(list, wbxml_buffer_destroy_item);
             return WBXML_ERROR_INTERNAL;
         }
 


### PR DESCRIPTION
When i=0, list is NULL. But subsequently as the loop iterates, "list" is allocated memory. Hence it need to be free before return at line:3766.
wbxml_list_destroy already checks if list is NULL, so no need to check for NULL before destroying "list" at this place.