### PR TITLE
CMake support for static library.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -76,3 +76,6 @@
     WBXML_SUPPORT_WV : Support of Wireless-Village CSP 1.1 / CSP 1.2
     
     HAVE_EXPAT : Enable XML Parsing feature (needs Expat)
+    
+    BUILD_SHARED_LIBS : Build wbxml as shared library
+    BUILD_STATIC_LIBS : Build wbxml as static library


### PR DESCRIPTION
CMake will support to build static library.
Added option to build either static, shared or both libraries.
Can be controlled using standard CMake flags : BUILD_SHARED_LIBS & BUILD_STATIC_LIBS.