### PR TITLE
CMake support for static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ ELSE( DIFF_PROGRAM )
 	SET( ENABLE_DIFF OFF )
 ENDIF( DIFF_PROGRAM )
 
+OPTION( BUILD_SHARED_LIBS "Build wbxml as shared library" ON )
+OPTION( BUILD_STATIC_LIBS "Build wbxml as static library" OFF )
 OPTION( WBXML_LIB_VERBOSE "verbose mode" OFF )
 OPTION( WBXML_ENCODER_USE_STRTBL "enable string tables" ON )
 OPTION( WBXML_SUPPORT_WML "enable WML support" ON )


### PR DESCRIPTION
CMake will support to build static library.
Added option to build either static, shared or both libraries.
Can be controlled using standard CMake flags : BUILD_SHARED_LIBS & BUILD_STATIC_LIBS.