### PR TITLE
CMake support for static library.

### DIFF
--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -14,7 +14,11 @@ FOREACH( SRC_FILE lists buffers base64 charset conv encoder_internals errors par
 
     ADD_EXECUTABLE(test_wbxml_${SRC_FILE} test_wbxml_${SRC_FILE}.c api_test.c)
 
+IF(BUILD_SHARED_LIBS)    
     TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} wbxml2)
+ELSE(BUILD_SHARED_LIBS)
+    TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} wbxml2_static)
+ENDIF()
 
     IF( PKG_CONFIG_FOUND )
     TARGET_LINK_LIBRARIES(test_wbxml_${SRC_FILE} ${CHECK_LDFLAGS})


### PR DESCRIPTION
CMake will support to build static library.
Added option to build either static, shared or both libraries.
Can be controlled using standard CMake flags : BUILD_SHARED_LIBS & BUILD_STATIC_LIBS.