### PR TITLE
Memory leak of ext when default case is executed.

### DIFF
--- a/src/wbxml_parser.c
+++ b/src/wbxml_parser.c
@@ -1625,6 +1625,7 @@ static WBXMLError parse_extension(WBXMLParser *parser, WBXMLTokenType code_space
             break;
 
         default:
+            wbxml_free(ext);
             return WBXML_ERROR_UNKNOWN_EXTENSION_TOKEN;
         }
     


### PR DESCRIPTION
 1585 : ext = wbxml_malloc(WBXML_STRLEN(var_begin) +
                           
ext malloced at line 1585 should be freed when default case is executed in line 1628.