### PR TITLE
Fixed MacOS X compiler warnings of Travis CI.

### DIFF
--- a/src/wbxml_buffers.c
+++ b/src/wbxml_buffers.c
@@ -518,7 +518,7 @@ WBXML_DECLARE(WBXMLList *) wbxml_buffer_split_words_real(WBXMLBuffer *buff)
 }
 
 
-WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, WB_UTINY ch, WB_ULONG pos, WB_ULONG *result)
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, const WB_UTINY ch, WB_ULONG pos, WB_ULONG *result)
 {
     WB_UTINY *p = NULL;
 
@@ -578,7 +578,7 @@ WBXML_DECLARE(WB_BOOL) wbxml_buffer_search(WBXMLBuffer *to, WBXMLBuffer *search,
 }
 
 
-WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, WB_UTINY *search, WB_ULONG pos, WB_ULONG *result)
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, const WB_UTINY *search, WB_ULONG pos, WB_ULONG *result)
 {
     WB_UTINY first = 0;
 

--- a/src/wbxml_buffers.h
+++ b/src/wbxml_buffers.h
@@ -269,7 +269,7 @@ WBXML_DECLARE(WBXMLList *) wbxml_buffer_split_words_real(WBXMLBuffer *buff);
  * @param result The start position of char in 'to' buffer
  * @return TRUE if char successfully found in 'to' buffer, FALSE otherwise
  */
-WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, WB_UTINY ch, WB_ULONG pos, WB_ULONG *result);
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, const WB_UTINY ch, WB_ULONG pos, WB_ULONG *result);
 
 /**
  * @brief Search a Buffer in another Buffer
@@ -289,7 +289,7 @@ WBXML_DECLARE(WB_BOOL) wbxml_buffer_search(WBXMLBuffer *to, WBXMLBuffer *search,
  * @param result The start position of 'search' buffer in 'to' buffer
  * @return TRUE if successfully found 'search' in 'to' buffer, FALSE otherwise
  */
-WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, WB_UTINY *search, WB_ULONG pos, WB_ULONG *result);
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, const WB_UTINY *search, WB_ULONG pos, WB_ULONG *result);
 
 /**
  * @brief Check if a buffer contains only Whitespaces

--- a/test/api/test_wbxml_base64.c
+++ b/test/api/test_wbxml_base64.c
@@ -1,6 +1,7 @@
 #include "api_test.h"
 
 #include "../../src/wbxml_base64.h"
+#include "../../src/wbxml_mem.h"
 
 START_TEST (test_encode)
 {
@@ -11,15 +12,15 @@ START_TEST (test_encode)
     ck_assert(wbxml_base64_encode(NULL, 0) == NULL);
     ck_assert(wbxml_base64_encode(NULL, 1) == NULL);
 
-    ck_assert(wbxml_base64_encode("", 0) == NULL);
-    ck_assert(wbxml_base64_encode("test", 0) == NULL);
+    ck_assert(wbxml_base64_encode((const WB_UTINY*) "", 0) == NULL);
+    ck_assert(wbxml_base64_encode((const WB_UTINY*) "test", 0) == NULL);
 
     /* encode a string */
 
-    result = wbxml_base64_encode("test", 4);
+    result = wbxml_base64_encode((const WB_UTINY*) "test", 4);
     ck_assert(result != NULL);
-    ck_assert(strlen(result) == 8);
-    ck_assert(strncmp(result, "dGVzdA==", 8) == 0);
+    ck_assert(WBXML_STRLEN(result) == 8);
+    ck_assert(WBXML_STRNCMP(result, "dGVzdA==", 8) == 0);
     wbxml_free(result);
 }
 END_TEST
@@ -32,13 +33,13 @@ START_TEST (test_decode)
 
     ck_assert(wbxml_base64_decode(NULL, 0, &result) <= 0);
     ck_assert(wbxml_base64_decode(NULL, 1, &result) <= 0);
-    ck_assert(wbxml_base64_decode("", 0, &result) <= 0);
-    ck_assert(wbxml_base64_decode("test", 0, &result) <= 0);
+    ck_assert(wbxml_base64_decode((const WB_UTINY*) "", 0, &result) <= 0);
+    ck_assert(wbxml_base64_decode((const WB_UTINY*) "test", 0, &result) <= 0);
 
     /* decode a string */
 
-    ck_assert(wbxml_base64_decode("dGVzdA==", 8, &result) == 4);
-    ck_assert(strncmp(result, "test", 4) == 0);
+    ck_assert(wbxml_base64_decode((const WB_UTINY*) "dGVzdA==", 8, &result) == 4);
+    ck_assert(WBXML_STRNCMP(result, "test", 4) == 0);
     wbxml_free(result);
 }
 END_TEST
@@ -50,9 +51,9 @@ START_TEST (test_encode_and_decode)
 
     /* encode */
 
-    enc = wbxml_base64_encode("test", 4);
-    ck_assert(wbxml_base64_decode(enc, strlen(enc), &dec) == 4);
-    ck_assert(strncmp(dec, "test", 4) == 0);
+    enc = wbxml_base64_encode((const WB_UTINY*) "test", 4);
+    ck_assert(wbxml_base64_decode(enc, WBXML_STRLEN(enc), &dec) == 4);
+    ck_assert(WBXML_STRNCMP(dec, "test", 4) == 0);
     wbxml_free(enc);
     wbxml_free(dec);
 }

--- a/test/api/test_wbxml_buffers.c
+++ b/test/api/test_wbxml_buffers.c
@@ -58,7 +58,7 @@ START_TEST (test_init_and_destroy_static)
     ck_assert( ! wbxml_buffer_set_char(buf, 3, 'c'));
 
     ck_assert( ! wbxml_buffer_insert(buf, buf2, 2));
-    ck_assert( ! wbxml_buffer_insert_cstr(buf, t2, 2));
+    ck_assert( ! wbxml_buffer_insert_cstr(buf, (const WB_UTINY*) t2, 2));
 
     ck_assert( ! wbxml_buffer_append(buf, buf2));
     ck_assert( ! wbxml_buffer_append_data(buf, t2, 2));
@@ -95,19 +95,19 @@ START_TEST (test_set_char)
     /* set first char */
 
     ck_assert(wbxml_buffer_set_char(buf, 0, 'T'));
-    ck_assert(wbxml_buffer_get_char(buf, 0, &c));
+    ck_assert(wbxml_buffer_get_char(buf, 0, (WB_UTINY *) &c));
     ck_assert(c == 'T');
 
     /* set middle char */
 
     ck_assert(wbxml_buffer_set_char(buf, 2, 'S'));
-    ck_assert(wbxml_buffer_get_char(buf, 2, &c));
+    ck_assert(wbxml_buffer_get_char(buf, 2, (WB_UTINY *) &c));
     ck_assert(c == 'S');
 
     /* set last char */
 
     ck_assert(wbxml_buffer_set_char(buf, 5, '2'));
-    ck_assert(wbxml_buffer_get_char(buf, 5, &c));
+    ck_assert(wbxml_buffer_get_char(buf, 5, (WB_UTINY *) &c));
     ck_assert(c == '2');
 
     /* set last+1 char */
@@ -198,36 +198,36 @@ START_TEST (test_insert)
 
     /* insert to an empty buffer */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "test", 0));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "test", 0));
     ck_assert(wbxml_buffer_len(buf) == 4);
 
     /* insert to head */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "1", 0));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "1", 0));
     ck_assert(wbxml_buffer_len(buf) == 5);
     ck_assert(wbxml_buffer_compare_cstr(buf, "1test") == 0);
 
     /* insert into middle */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "23", 1));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "23", 1));
     ck_assert(wbxml_buffer_len(buf) == 7);
     ck_assert(wbxml_buffer_compare_cstr(buf, "123test") == 0);
 
     /* insert at end */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "7", 6));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "7", 6));
     ck_assert(wbxml_buffer_len(buf) == 8);
     ck_assert(wbxml_buffer_compare_cstr(buf, "123tes7t") == 0);
 
     /* insert after end */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "9", 8));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "9", 8));
     ck_assert(wbxml_buffer_len(buf) == 9);
     ck_assert(wbxml_buffer_compare_cstr(buf, "123tes7t9") == 0);
 
     /* insert far after end */
 
-    ck_assert( ! wbxml_buffer_insert_cstr(buf, "10", 10));
+    ck_assert( ! wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "10", 10));
     ck_assert(wbxml_buffer_len(buf) == 9);
     ck_assert(wbxml_buffer_compare_cstr(buf, "123tes7t9") == 0);
 
@@ -261,7 +261,7 @@ START_TEST (test_delete)
 
     /* insert */
 
-    ck_assert(wbxml_buffer_insert_cstr(buf, "test", 0));
+    ck_assert(wbxml_buffer_insert_cstr(buf, (const WB_UTINY *) "test", 0));
     ck_assert(wbxml_buffer_len(buf) == 4);
 
     /* delete head */
@@ -354,12 +354,12 @@ START_TEST (test_search)
     ck_assert(! wbxml_buffer_search(buf, buf2, 0, &l));
     ck_assert(! wbxml_buffer_search(buf, NULL, 0, &l));
 
-    ck_assert(! wbxml_buffer_search_cstr(NULL, "123", 0, &l));
-    ck_assert(! wbxml_buffer_search_cstr(NULL, "", 0, &l));
+    ck_assert(! wbxml_buffer_search_cstr(NULL, (const WB_UTINY *) "123", 0, &l));
+    ck_assert(! wbxml_buffer_search_cstr(NULL, (const WB_UTINY *) "", 0, &l));
     ck_assert(! wbxml_buffer_search_cstr(NULL, NULL, 0, &l));
-    ck_assert(! wbxml_buffer_search_cstr(buf, "123", 0, &l));
+    ck_assert(! wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "123", 0, &l));
     l = 1;
-    ck_assert(wbxml_buffer_search_cstr(buf, "", 0, &l));
+    ck_assert(wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "", 0, &l));
     ck_assert(l == 0);
     ck_assert(! wbxml_buffer_search_cstr(buf, NULL, 0, &l));
 
@@ -382,10 +382,10 @@ START_TEST (test_search)
     ck_assert(! wbxml_buffer_search(buf, buf2, 5, NULL));
 
     l = 1;
-    ck_assert(wbxml_buffer_search_cstr(buf, "123", 0, &l));
+    ck_assert(wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "123", 0, &l));
     ck_assert(l == 4);
-    ck_assert(wbxml_buffer_search_cstr(buf, "123", 0, NULL));
-    ck_assert(wbxml_buffer_search_cstr(buf, "", 0, &l));
+    ck_assert(wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "123", 0, NULL));
+    ck_assert(wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "", 0, &l));
     ck_assert(l == 0);
     ck_assert(! wbxml_buffer_search_cstr(buf, NULL, 0, &l));
 
@@ -393,7 +393,7 @@ START_TEST (test_search)
 
     ck_assert(! wbxml_buffer_search_char(buf, '3', wbxml_buffer_len(buf), &l));
     ck_assert(! wbxml_buffer_search(buf, buf2, wbxml_buffer_len(buf), &l));
-    ck_assert(! wbxml_buffer_search_cstr(buf, "3", wbxml_buffer_len(buf), &l));
+    ck_assert(! wbxml_buffer_search_cstr(buf, (const WB_UTINY *) "3", wbxml_buffer_len(buf), &l));
 
     wbxml_buffer_destroy(buf);
     wbxml_buffer_destroy(buf2);

--- a/test/api/test_wbxml_errors.c
+++ b/test/api/test_wbxml_errors.c
@@ -4,31 +4,31 @@
 
 START_TEST (security_test_errors_datetime_without_percent)
 {
-    ck_assert(strchr(wbxml_errors_string(WBXML_ERROR_BAD_DATETIME), '%') == NULL);
+    ck_assert(WBXML_STRSTR(wbxml_errors_string(WBXML_ERROR_BAD_DATETIME), "%") == NULL);
 }
 END_TEST
 
 START_TEST (test_errors_ok)
 {
     ck_assert(wbxml_errors_string(WBXML_OK) != NULL);
-    ck_assert(strcmp(wbxml_errors_string(WBXML_OK), "Unknown Error Code") != 0);
+    ck_assert(WBXML_STRCMP(wbxml_errors_string(WBXML_OK), "Unknown Error Code") != 0);
 }
 END_TEST
 
 START_TEST (test_errors_last_item)
 {
     ck_assert(wbxml_errors_string(WBXML_ERROR_XMLPARSER_OUTPUT_UTF16) != NULL);
-    ck_assert(strcmp(wbxml_errors_string(WBXML_ERROR_XMLPARSER_OUTPUT_UTF16), "Unknown Error Code") != 0);
+    ck_assert(WBXML_STRCMP(wbxml_errors_string(WBXML_ERROR_XMLPARSER_OUTPUT_UTF16), "Unknown Error Code") != 0);
 
     ck_assert(wbxml_errors_string(WBXML_ERROR_CHARSET_NOT_FOUND) != NULL);
-    ck_assert(strcmp(wbxml_errors_string(WBXML_ERROR_CHARSET_NOT_FOUND), "Unknown Error Code") != 0);
+    ck_assert(WBXML_STRCMP(wbxml_errors_string(WBXML_ERROR_CHARSET_NOT_FOUND), "Unknown Error Code") != 0);
 }
 END_TEST
 
 START_TEST (test_errors_unknown_error_code)
 {
     ck_assert(wbxml_errors_string(127) != NULL);
-    ck_assert(strcmp(wbxml_errors_string(127), "Unknown Error Code") == 0);
+    ck_assert(WBXML_STRCMP(wbxml_errors_string(127), "Unknown Error Code") == 0);
 }
 END_TEST
 


### PR DESCRIPTION
Fixed MacOS X compiler warnings of Travis CI. This includes two fixes of the internal buffer API.