### PR TITLE
Added fix from issue #58 to correct encoding of Microsoft ActiveSync.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+  * Fixed/changed the encoding of element Content in CodePage
+    AirSyncBase (0x11) to WBXML_BINARY_OPTION for Microsoft ActiveSync.
+    This element is used when the clients send a request to save a draft
+    email. An example can be found in:
+      http://interoperability.blob.core.windows.net/files/MS-ASEMAIL/[MS-ASEMAIL].pdf
+    (4.4 Adding a Draft Email with Attachments).
+    Reference:
+      https://msdn.microsoft.com/en-us/library/mt563406%28v=exchg.80%29.aspx
+    (issue #58 from Thomas Führer)
   * Added a testcase for Microsoft ActiveSync EAS Provisioning
     (clarifies issue #56).
 

--- a/src/wbxml_tables.c
+++ b/src/wbxml_tables.c
@@ -3088,7 +3088,7 @@ const WBXMLTagEntry sv_airsync_tag_table[] = {
     { "Add",                    0x11, 0x1c }, /* since 16.0 */
     { "Delete",                 0x11, 0x1d }, /* since 16.0 */
     { "ClientId",               0x11, 0x1e }, /* since 16.0 */
-    { "Content",                0x11, 0x1f }, /* since 16.0 */
+    { "Content",                0x11, 0x1f, WBXML_TAG_OPTION_BINARY }, /* since 16.0 */
     { "Location",               0x11, 0x20 }, /* since 16.0 */
     { "Annotation",             0x11, 0x21 }, /* since 16.0 */
     { "Street",                 0x11, 0x22 }, /* since 16.0 */


### PR DESCRIPTION
ActiveSync => Code page: 0x11 AirSyncBase => Content => WBXML_BINARY_OPTION