### PR TITLE
Fix memory leak detected by leak-sanitizer

### DIFF
--- a/test/api/test_wbxml_base64.c
+++ b/test/api/test_wbxml_base64.c
@@ -34,7 +34,9 @@ START_TEST (test_decode)
     ck_assert(wbxml_base64_decode(NULL, 0, &result) <= 0);
     ck_assert(wbxml_base64_decode(NULL, 1, &result) <= 0);
     ck_assert(wbxml_base64_decode((const WB_UTINY*) "", 0, &result) <= 0);
+    wbxml_free(result);
     ck_assert(wbxml_base64_decode((const WB_UTINY*) "test", 0, &result) <= 0);
+    wbxml_free(result);
 
     /* decode a string */
 


### PR DESCRIPTION
Patch for below issue detected by leak-sanitizer:
./test_wbxml_base64
Running suite(s): name

=================================================================
==26991==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f97d0b92a18 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:38
    #1 0x7f97d0874151 in wbxml_malloc My_DIR/libwbxml-master/src/wbxml_mem.c:48
    #2 0x7f97d085ce76 in wbxml_base64_decode My_DIR/libwbxml-master/src/wbxml_base64.c:137
    #3 0x40329a in test_decode My_DIR/libwbxml-master/test/api/test_wbxml_base64.c:36
    #4 0x405f36 in srunner_run (My_DIR/libwbxml-master/build/test/api/test_wbxml_base64+0x405f36)

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f97d0b92a18 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:38
    #1 0x7f97d0874151 in wbxml_malloc My_DIR/libwbxml-master/src/wbxml_mem.c:48
    #2 0x7f97d085ce76 in wbxml_base64_decode My_DIR/libwbxml-master/src/wbxml_base64.c:137
    #3 0x4032df in test_decode My_DIR/libwbxml-master/test/api/test_wbxml_base64.c:37
    #4 0x405f36 in srunner_run (My_DIR/libwbxml-master/build/test/api/test_wbxml_base64+0x405f36)

SUMMARY: AddressSanitizer: 2 byte(s) leaked in 2 allocation(s).
66%: Checks: 3, Failures: 0, Errors: 1