### PR TITLE
Fix leak-sanitizer issues in tools

### DIFF
--- a/tools/wbxml2xml_tool.c
+++ b/tools/wbxml2xml_tool.c
@@ -367,14 +367,14 @@ WB_LONG main(WB_LONG argc, WB_TINY **argv)
         case '?':
         default:
             help();
-            return 0;
+            goto clean_up;
         }
     }
 
     if (optind >= argc) {
         fprintf(stderr, "Missing arguments\n");
         help();
-        return 0;
+        goto clean_up;
     }
 
 #ifdef WBXML_USE_LEAKTRACKER

--- a/tools/xml2wbxml_tool.c
+++ b/tools/xml2wbxml_tool.c
@@ -146,14 +146,14 @@ WB_LONG main(WB_LONG argc, WB_TINY **argv)
         case '?':
         default:
             help();
-            return 0;
+            goto clean_up;
         }
     }
 
     if (optind >= argc) {
         fprintf(stderr, "Missing arguments\n");
         help();
-        return 0;
+        goto clean_up;
     }
 
 #ifdef WBXML_USE_LEAKTRACKER


### PR DESCRIPTION
Below errors are reported.
==12503==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f1353996a18 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:38
    #1 0x7f1353678151 in wbxml_malloc My_DIR/libwbxml-master/src/wbxml_mem.c:48
    #2 0x7f1353665f72 in wbxml_conv_wbxml2xml_create My_DIR/libwbxml-master/src/wbxml_conv.c:71
    #3 0x402a24 in main My_DIR/libwbxml-master/tools/wbxml2xml_tool.c:326
    #4 0x7f1353059f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

	
==6407==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fbbac2b3a18 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:38
    #1 0x7fbbabf95151 in wbxml_malloc My_DIR/libwbxml-master/src/wbxml_mem.c:48
    #2 0x7fbbabf837b9 in wbxml_conv_xml2wbxml_create My_DIR/libwbxml-master/src/wbxml_conv.c:219
    #3 0x401a7b in main My_DIR/libwbxml-master/tools/xml2wbxml_tool.c:119
    #4 0x7fbbab976f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)