### PR TITLE
Fix outside library loading

### DIFF
--- a/test/tools/launchTests.sh
+++ b/test/tools/launchTests.sh
@@ -45,7 +45,7 @@ fi
 # Debian does this by default
 if [ "${CMAKE_SKIP_RPATH}" ]
 then
-	LD_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}/../../src"
+	LD_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}/../../src:$LD_LIBRARY_PATH"
 	export LD_LIBRARY_PATH
 fi
 


### PR DESCRIPTION
When enabling Asan (address sanitizer) feature in gcc, the libasan library is not getting loaded due to fixed LD_LIBRARY_PATH.
Modify to take external lib loading path also to maintain generic behaviour.