### PR TITLE
Use internal local header rather than installed header.

### DIFF
--- a/src/wbxml_tree.h
+++ b/src/wbxml_tree.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <wbxml_config.h>
+#include "wbxml_config.h"
 
 /** @addtogroup wbxml_tree
  *  @{ 


### PR DESCRIPTION
This minor change ensures the internal header file is used rather than the system installed header file.