### PR TITLE
Provide option to install internal header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,20 @@ MATH( EXPR LIBWBXML_LIBVERSION_SOVERSION "${LIBWBXML_LIBVERSION_CURRENT} - ${LIB
 
 SET( LIBWBXML_LIBVERSION_VERSION "${LIBWBXML_LIBVERSION_SOVERSION}.${LIBWBXML_LIBVERSION_AGE}.${LIBWBXML_LIBVERSION_REVISION}" )
 
+# this hack protects the SO versioning of the library
+# it makes the exposing of internal header files possible and safe
+# usual library version: 2.6.1
+# special library version: 20601.0.0
+IF( WBXML_INSTALL_FULL_HEADERS )
+
+    # calculate big major version
+    MATH( EXPR LIBWBXML_LIBVERSION_SOVERSION "10000 * ${LIBWBXML_LIBVERSION_SOVERSION} + 100 * ${LIBWBXML_LIBVERSION_AGE} + ${LIBWBXML_LIBVERSION_REVISION}" )
+
+    # build a x.0.0 version
+    SET( LIBWBXML_LIBVERSION_VERSION "${LIBWBXML_LIBVERSION_SOVERSION}.0.0" )
+
+ENDIF( WBXML_INSTALL_FULL_HEADERS )
+
 CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
 
 # TODO: Move to external file/macro
@@ -151,6 +165,7 @@ OPTION( WBXML_SUPPORT_SYNCML "enable SYNCML support" ON )
 OPTION( WBXML_SUPPORT_WV "enable WV support" ON )
 OPTION( WBXML_SUPPORT_AIRSYNC "enable AIRSYNC support" ON )
 OPTION( WBXML_SUPPORT_CONML "enable Nokia ConML support" ON )
+OPTION( WBXML_INSTALL_FULL_HEADERS "install internal headers" OFF )
 
 SET( PACKAGE "libwbxml" )
 SET( PACKAGE_BUGREPORT " " )
@@ -233,6 +248,7 @@ SHOW_STATUS( WBXML_SUPPORT_CONML "enable Nokia ConML support\t" )
 SHOW_STATUS( BUILD_DOCUMENTATION "build dynamic documentation\t" )
 SHOW_STATUS( WBXML_SUPPORT_ICONV "enable iconv support\t\t" )
 SHOW_STATUS( ENABLE_INSTALL_DOC "install documentation\t" )
+SHOW_STATUS( WBXML_INSTALL_FULL_HEADERS "install internal headers\t" )
 
 # fatal error detection
 IF ( FATAL_ERROR_EXPAT )

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+  * Added WBXML_INSTALL_FULL_HEADERS cmake flag to expose internal API
+    headers; changes version for compatibility (e.g. 2.6.1 -> 20601.0.0)
+
 2017-08-15  Michael Bell <michael.bell@web.de>
   * Released 0.11.6
   * Fixed/changed the encoding of element Content in CodePage

--- a/INSTALL
+++ b/INSTALL
@@ -74,8 +74,11 @@
     WBXML_SUPPORT_OTA_SETTINGS : Support of Ericsson / Nokia OTA Settings v7.0
     WBXML_SUPPORT_SYNCML : Support of SyncML 1.0 / SyncML 1.1 / SyncML 1.2
     WBXML_SUPPORT_WV : Support of Wireless-Village CSP 1.1 / CSP 1.2
+    WBXML_SUPPORT_AIRSYNC : Support of AIRSYNC 2.5
+    WBXML_SUPPORT_CONML : Support of Nokia ConML
     
     HAVE_EXPAT : Enable XML Parsing feature (needs Expat)
+    WBXML_INSTALL_FULL_HEADERS : Install unstable internal API headers
     
     BUILD_SHARED_LIBS : Build wbxml as shared library
     BUILD_STATIC_LIBS : Build wbxml as static library

--- a/THANKS
+++ b/THANKS
@@ -8,22 +8,24 @@ Michael Bell <michael.bell@web.de>
 
 The following people helped to develop and maintain this library:
 
-Amnon Aaronsohn     (ActiveSync)
-Pau Aliagas         <pau@smsarena.com>
-Michael Banck       (Debian package maintainer, testing)
-Michael Bell        <michael.bell@web.de>
-Gaurav Gupta        <g.gupta@samsung.com>
-Gil Hartmann        (Active Sync v16.0)
-Conrad Irwin        (performance fixes)
-Aymerick Jehanne    <aymerick@jehanne.org>
-Ossi Jormakka       (Ixonos Plc., ActiveSync)
-Anton D. Kachalov   (Nokia ConML support)
-Benedykt Kroplewski <benedykt@age.pl>
-Jeremy Lainé        (helped with cmake on Win32)
-Mark Ostrer         (Websense)
-Petr Písař          (RedHat/Fedora package maintainer)
-Renu Tyagi          (fixed some memory leaks)
-Boaz Yaniv          (MS Visual Studio fixes)
+Amnon Aaronsohn       (ActiveSync)
+Pau Aliagas           <pau@smsarena.com>
+Michael Banck         (Debian package maintainer, testing)
+Michael Bell          <michael.bell@web.de>
+Gaurav Gupta          <g.gupta@samsung.com>
+Gil Hartmann          (Active Sync v16.0)
+Conrad Irwin          (performance fixes)
+Aymerick Jehanne      <aymerick@jehanne.org>
+Ossi Jormakka         (Ixonos Plc., ActiveSync)
+Anton D. Kachalov     (Nokia ConML support)
+Benedykt Kroplewski   <benedykt@age.pl>
+Jeremy Lainé          (helped with cmake on Win32)
+Mark Ostrer           (Websense)
+Petr Písař            (RedHat/Fedora package maintainer)
+Renu Tyagi            (fixed some memory leaks)
+Boaz Yaniv            (MS Visual Studio fixes)
+Slava Monich          <slava@monich.com>
+David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
 
 If you think your name is missing here
 then please feel free to create a ticket.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,3 +64,22 @@ INSTALL( FILES
 	DESTINATION ${LIBWBXML_INCLUDE_DIR}/wbxml
 )
 
+IF(WBXML_INSTALL_FULL_HEADERS)
+    INSTALL( FILES
+        wbxml_base64.h
+        wbxml_buffers.h
+        wbxml_charset.h
+        wbxml_elt.h
+        wbxml_encoder.h
+        wbxml_handlers.h
+        wbxml_lists.h
+        wbxml_log.h
+        wbxml_mem.h
+        wbxml_parser.h
+        wbxml_tables.h
+        wbxml_tree.h
+        wbxml_tree_clb_wbxml.h
+        wbxml_tree_clb_xml.h
+        DESTINATION ${LIBWBXML_INCLUDE_DIR}/wbxml
+    )
+ENDIF()


### PR DESCRIPTION
Back in January 2011 the API [was reduced](https://github.com/libwbxml/libwbxml/commit/4add46f7a27efd326dfbaddd11bf3aec86602642) to expose (as I understand it) only the XML<-->WBXML conversion functions.

We have a number of projects that make more direct use of the API (for example [see here](https://git.sailfishos.org/mer-core/provisioning-service/blob/master/src/provisioning-decoder.c)), and in the process of updating them to the latest version (please don't ask why it's taken over 8 years to do this) I stumbled on this change.

In order to get these projects to build without access to the (now internal) header files, significant changes to them would be required. In fact I'm unclear on how this is supposed to be achieved with just the API now visible, but it looks like it would require us to use a different library (maybe the intention is to construct the data as XML and then use libwbxml to convert to WBXML?).

This patch provides a CMake flag `WBXML_INSTALL_FULL_HEADERS` to allow the package to be built in a way that exposes the internal header files. I'm perhaps being a bit optimistic and this may be completely the wrong way to solve this; if there are other options available then I'd appreciate any pointers.