### PR TITLE
Change namespace separator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+  * Change the default internal namespace separator from the colon to the pipe
+    (issue #76 from Sebastian Pipping, fixed in pull request #78 from Slávek Banko).
+    This solves compatibility with libexpat >= 2.4.5 after fix the security
+    problem CVE-2022-25236.
   * Removed copy of Expat in macosx directory (issue #77).
 
 2020-04-15  Michael Bell <michael.bell@web.de>

--- a/THANKS
+++ b/THANKS
@@ -27,6 +27,7 @@ Renu Tyagi               (fixed some memory leaks)
 Boaz Yaniv               (MS Visual Studio fixes)
 Slava Monich             <slava@monich.com>
 David Llewellyn-Jones    <david.llewellyn-jones@jolla.com>
+Slávek Banko             <slavek.banko@axis.cz>
 
 If you think your name is missing here
 then please feel free to create a ticket.

--- a/src/wbxml_internals.h
+++ b/src/wbxml_internals.h
@@ -156,7 +156,9 @@ typedef enum WBXMLWVDataType_e {
 #pragma warning(error: 4761) /**< integral size mismatch in argument : conversion supplied */
 #endif /* WIN32 */
 
-#define WBXML_NAMESPACE_SEPARATOR ':'
+/* Separator must be the same in both cases - once as a char, once as a string */
+#define WBXML_NAMESPACE_SEPARATOR     ':'
+#define WBXML_NAMESPACE_SEPARATOR_STR ":"
 
 /** @} */
 

--- a/src/wbxml_internals.h
+++ b/src/wbxml_internals.h
@@ -157,8 +157,8 @@ typedef enum WBXMLWVDataType_e {
 #endif /* WIN32 */
 
 /* Separator must be the same in both cases - once as a char, once as a string */
-#define WBXML_NAMESPACE_SEPARATOR     ':'
-#define WBXML_NAMESPACE_SEPARATOR_STR ":"
+#define WBXML_NAMESPACE_SEPARATOR     '|'
+#define WBXML_NAMESPACE_SEPARATOR_STR "|"
 
 /** @} */
 

--- a/src/wbxml_parser.c
+++ b/src/wbxml_parser.c
@@ -2479,7 +2479,8 @@ static WBXMLError decode_opaque_content(WBXMLParser  *parser,
     case WBXML_LANG_SYNCML_SYNCML11: 
     case WBXML_LANG_SYNCML_SYNCML12: 
         /* NextNonce */
-        if ((parser->current_tag->wbxmlCodePage == 0x01) &&
+        if ((parser->current_tag) &&
+            (parser->current_tag->wbxmlCodePage == 0x01) &&
             (parser->current_tag->wbxmlToken == 0x10)) 
         {
             /* Decode base64 value */ 

--- a/src/wbxml_tree_clb_xml.c
+++ b/src/wbxml_tree_clb_xml.c
@@ -33,6 +33,7 @@
  * @brief WBXML Tree Callbacks for XML Parser (Expat)
  */
 
+#include "wbxml_internals.h"
 #include "wbxml_config_internals.h"
 
 #if defined( HAVE_EXPAT )
@@ -160,8 +161,8 @@ void wbxml_tree_clb_xml_start_element(void           *ctx,
      * potentially embedded documents.
      */
     if ((
-         (WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0) ||
-         (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0)
+         (WBXML_STRCMP(localName, "syncml:devinf" WBXML_NAMESPACE_SEPARATOR_STR "DevInf") == 0) ||
+         (WBXML_STRCMP(localName, "syncml:dmddf1.2" WBXML_NAMESPACE_SEPARATOR_STR "MgmtTree") == 0)
         )&&
         (tree_ctx->current != NULL))
     {
@@ -255,8 +256,8 @@ void wbxml_tree_clb_xml_end_element(void           *ctx,
             /* End of skipped node */
 
 #if defined( WBXML_SUPPORT_SYNCML )
-            if (WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0 ||
-	        WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0) {
+            if (WBXML_STRCMP(localName, "syncml:devinf" WBXML_NAMESPACE_SEPARATOR_STR "DevInf") == 0 ||
+	        WBXML_STRCMP(localName, "syncml:dmddf1.2" WBXML_NAMESPACE_SEPARATOR_STR "MgmtTree") == 0) {
 		/* definitions first ... or some compilers don't like it */
                 WBXMLBuffer *embed_doc = NULL;
                 WBXMLTree *tree = NULL;
@@ -277,10 +278,10 @@ void wbxml_tree_clb_xml_end_element(void           *ctx,
                 }
 
                 /* Check Buffer Creation and add the closing tag */
-		if ((WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0 &&
+		if ((WBXML_STRCMP(localName, "syncml:devinf" WBXML_NAMESPACE_SEPARATOR_STR "DevInf") == 0 &&
 		     (!wbxml_buffer_append_cstr(embed_doc, "</DevInf>")))
                     ||
-		    (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0 &&
+		    (WBXML_STRCMP(localName, "syncml:dmddf1.2" WBXML_NAMESPACE_SEPARATOR_STR "MgmtTree") == 0 &&
 		     (!wbxml_buffer_append_cstr(embed_doc, "</MgmtTree>"))))
                 {
                     tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
@@ -289,7 +290,7 @@ void wbxml_tree_clb_xml_end_element(void           *ctx,
                 }
 
                 /* Add doctype to give the XML parser a chance */
-		if (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0 &&
+		if (WBXML_STRCMP(localName, "syncml:dmddf1.2" WBXML_NAMESPACE_SEPARATOR_STR "MgmtTree") == 0 &&
 		    tree_ctx->tree->lang->langID != WBXML_LANG_SYNCML_SYNCML12)
 		{
                     tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
@@ -305,7 +306,7 @@ void wbxml_tree_clb_xml_end_element(void           *ctx,
 				lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DEVINF11);
 				break;
 			case WBXML_LANG_SYNCML_SYNCML12:
-				if (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0) {
+				if (WBXML_STRCMP(localName, "syncml:dmddf1.2" WBXML_NAMESPACE_SEPARATOR_STR "MgmtTree") == 0) {
 					lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DMDDF12);
 				} else {
 					lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DEVINF12);


### PR DESCRIPTION
Three parts are addressed:
1. Crash in case of damaged wbxml file.
2. Hard-coded colon as a namespace separator in SyncML related code.
3. Change the default namespace separator.

See previous comments on issue #76.