### PR TITLE
Changed location of releases to GitHub in README and minor SVN cleanup.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+  * Changed location of releases to GitHub only in README.
   * Change the default internal namespace separator from the colon to the pipe
     (issue #76 from Sebastian Pipping, fixed in pull request #78 from Slávek Banko).
     This solves compatibility with libexpat >= 2.4.5 after fix the security

--- a/README
+++ b/README
@@ -150,6 +150,11 @@
         Please use GitHub to report bugs, ask questions or submit code:
         https://github.com/libwbxml/libwbxml
 
-        Releases can be found on Sourceforge too:
+        Releases can be found on GitHub too:
+        https://github.com/libwbxml/libwbxml/releases
+
+        In the past, releases were published on SourceForge:
         https://sourceforge.net/projects/libwbxml/
+
+        Today, releases are only published on GitHub.
 

--- a/RELEASE
+++ b/RELEASE
@@ -25,7 +25,6 @@ To make a release of libwbxml, do the following:
       If any interface has been added then increment.
 
  - Run "make test" again several times to try to see race conditions.
-   "cd trunk"
    "cmake . -B/tmp/build/libwbxml"
    "cd /tmp/build/libwbxml"
    "make"


### PR DESCRIPTION
This is a fix for issue #80.