### PR TITLE
tests: Check for normalize_xml.pl failure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+  * Check for normalize_xml.pl failures in the tests (pull request #84).
+
 2022-02-28  Michael Bell <michael.bell@web.de>
   * Released 0.11.8
   * Changed location of releases to GitHub only in README.

--- a/test/tools/launchTests.sh
+++ b/test/tools/launchTests.sh
@@ -172,7 +172,9 @@ do
 	echo CDATA_ENCAPSULATION
     else
 	$PERL_BIN $NORMALIZE_SCRIPT --delete-attribute xmlns $j $OUT_XML.org
+	if [ $? != 0 ]; then echo FAILED; RESULT="FAILED"; continue; fi
 	$PERL_BIN $NORMALIZE_SCRIPT --delete-attribute xmlns $OUT_XML $OUT_XML.new
+	if [ $? != 0 ]; then echo FAILED; RESULT="FAILED"; continue; fi
 	DIFF_RESULT=`$DIFF_BIN -b $OUT_XML.org $OUT_XML.new`
 	if [ " $DIFF_RESULT" != " " ];
 	then


### PR DESCRIPTION
When I introduced an error into test/tools/normalize_xml.pl, the
launchTests.sh kept reporting success:

~~~~
$ ./launchTests.sh /tmp/libwbxml/test/tools activesync 1
Test suite directory is /tmp/libwbxml/test/tools
----------------------------
Entering into: activesync
----------------------------
. activesync-001-settings_device_information.xml
Converting into: /tmp/LibWBXMLTestSuite.iS8/activesync/activesync-001-settings_device_information.wbxml
xml2wbxml succeeded
Converting back: /tmp/LibWBXMLTestSuite.iS8/activesync/activesync-001-settings_device_information.xml
wbxml2xml succeeded
Comparing the original and the generated XML ... Can't locate XXX/English.pm in @INC (you may need to install the XXX::English module) (@INC contains: /usr/local/lib64/perl5/5.34 /usr/local/share/perl5/5.34 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /tmp/build/test/tools/normalize_xml.pl line 7.
BEGIN failed--compilation aborted at /tmp/build/test/tools/normalize_xml.pl line 7.
Can't locate XXX/English.pm in @INC (you may need to install the XXX::English module) (@INC contains: /usr/local/lib64/perl5/5.34 /usr/local/share/perl5/5.34 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /tmp/build/test/tools/normalize_xml.pl line 7.
BEGIN failed--compilation aborted at /tmp/build/test/tools/normalize_xml.pl line 7.
/usr/bin/diff: /tmp/LibWBXMLTestSuite.iS8/activesync/activesync-001-settings_device_information.xml.org: No such file or directory
/usr/bin/diff: /tmp/LibWBXMLTestSuite.iS8/activesync/activesync-001-settings_device_information.xml.new: No such file or directory
SUCCEEDED
---------------------------
\o/ Finished ! Yeah ! \o/
---------------------------
SUCCEEDED
~~~~

This patch fixes it by checking an exit code of normalize_xml.pl.