### PR TITLE
Remove unused variables

### DIFF
--- a/src/wbxml_buffers.c
+++ b/src/wbxml_buffers.c
@@ -373,7 +373,7 @@ WBXML_DECLARE(WB_BOOL) wbxml_buffer_strip_blanks(WBXMLBuffer *buffer)
 
 WBXML_DECLARE(void) wbxml_buffer_no_spaces(WBXMLBuffer *buffer)
 {
-    WB_ULONG i = 0, j = 0, end = 0;
+    WB_ULONG i = 0;
     WB_UTINY ch = 0;
     
     if ((buffer == NULL) || buffer->is_static)

--- a/src/wbxml_parser.c
+++ b/src/wbxml_parser.c
@@ -2845,7 +2845,6 @@ static WBXMLError decode_wv_datetime(WBXMLBuffer **data)
               the_hour[3], the_minute[3], the_second[3],
               result[17];
     WB_ULONG the_value = 0;
-    WBXMLError ret = WBXML_OK;
   
     /** @todo Test decode_wv_datetime() ! */
   
@@ -2914,7 +2913,7 @@ static WBXMLError decode_wv_datetime(WBXMLBuffer **data)
 
     /* Set data */
     if (!wbxml_buffer_append_cstr(*data, result)) {
-        ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
     }
   
     return WBXML_OK;

--- a/src/wbxml_tree.c
+++ b/src/wbxml_tree.c
@@ -53,7 +53,9 @@ WBXML_DECLARE(WBXMLError) wbxml_tree_from_wbxml(WB_UTINY *wbxml,
                                                 WBXMLTree **tree)
 {
     WBXMLParser *wbxml_parser = NULL;
-    WB_LONG error_index = 0;
+#if defined( WBXML_LIB_VERBOSE )
+    WB_LONG error_index;
+#endif
     WBXMLTreeClbCtx wbxml_tree_clb_ctx;
     WBXMLError ret = WBXML_OK;
     WBXMLContentHandler wbxml_tree_content_handler = 
@@ -100,11 +102,13 @@ WBXML_DECLARE(WBXMLError) wbxml_tree_from_wbxml(WB_UTINY *wbxml,
     ret = wbxml_parser_parse(wbxml_parser, wbxml, wbxml_len);
     if ((ret != WBXML_OK) || (wbxml_tree_clb_ctx.error != WBXML_OK)) 
     {
+#if defined( WBXML_LIB_VERBOSE )
         error_index = wbxml_parser_get_current_byte_index(wbxml_parser);
         WBXML_ERROR((WBXML_PARSER, "WBXML Parser failed at %ld - token: %x (%s)", 
                                    error_index,
                                    wbxml[error_index],
                                    ret != WBXML_OK ? wbxml_errors_string(ret) : wbxml_errors_string(wbxml_tree_clb_ctx.error)));
+#endif
         
         wbxml_tree_destroy(wbxml_tree_clb_ctx.tree);
     }

--- a/test/api/test_wbxml_encoder_internals.c
+++ b/test/api/test_wbxml_encoder_internals.c
@@ -6,7 +6,6 @@ START_TEST (security_test_xml_build_result_null_params)
 {
     WBXMLEncoder *enc = NULL;
     WB_UTINY *xml = NULL;
-    WB_ULONG len = 0;
 
     enc = wbxml_encoder_create();
 


### PR DESCRIPTION
Building with -Wall compiler option, GCC reports a few unused variables. This patch fixes the warnings.

A notable case was in decode_wv_datetime() where a memory allocation failure was ignored.