### PR TITLE
Removed pragma 4061 from wbxml_internals.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+  * Removed pragma 4061 from wbxml_internals.h which caused compiler
+    errors on win32 platform (issue #75).
+
 2024-06-17  Michael Bell <michael.bell@web.de>
   * Released 0.11.10
   * Removed a few unused variables which gcc reported during building

--- a/src/wbxml_internals.h
+++ b/src/wbxml_internals.h
@@ -126,7 +126,6 @@ typedef enum WBXMLWVDataType_e {
 #pragma warning(error: 4054) /**< 'conversion' : from function pointer 'type1' to data pointer 'type2' */
 #pragma warning(error: 4057) /**< 'operator' : 'identifier1' indirection to slightly different base types from 'identifier2' */
 #pragma warning(error: 4059) /**< pascal string too big, length byte is length % 256 */
-#pragma warning(error: 4061) /**< enumerate 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label */
 #pragma warning(error: 4063) /**< case 'identifier' is not a valid value for switch of enum 'identifier' */
 #pragma warning(error: 4064) /**< switch of incomplete enum 'identifier' */
 #pragma warning(error: 4071) /**< 'function' : no function prototype given */


### PR DESCRIPTION
Removed pragma 4061 from wbxml_internals.h which caused compiler errors on win32 platform (issue #75).