### PR TITLE
Fix installing CMake configuration files

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Standard header and include paths were already defined.
 
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 configure_package_config_file(
     libwbxml2-config.cmake.in


### PR DESCRIPTION
libwbxml2-config.cmake was installed into /cmake/libwbxml2 directory because CMAKE_INSTALL_LIBDIR was not set:

    /usr/bin/cmake --install redhat-linux-build
    -- Install configuration: ""
    -- Installing: /home/test/fedora/libwbxml/libwbxml-0.11.10-build/BUILDROOT/usr/lib64/pkgconfig/libwbxml
    [...]
    -- Installing: /home/test/fedora/libwbxml/libwbxml-0.11.10-build/BUILDROOT/cmake/libwbxml2/libwbxml2-config.cmake
    -- Installing: /home/test/fedora/libwbxml/libwbxml-0.11.10-build/BUILDROOT/cmake/libwbxml2/libwbxml2-config-version.cmake

The root cause was that CMAKE_INSTALL_LIBDIR is defined by GNUInstallDirs module which was not included.

This patch fixes it.