### PR TITLE
Fix a pkg-config fallback from CMake scripts when detecting Expat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ MACRO_ENSURE_OUT_OF_SOURCE_BUILD("${CMAKE_PROJECT_NAME} doesn't allow to build w
 # nsl is part of libc6
 
 # Expat support
-FIND_PACKAGE( Expat REQUIRED )
+FIND_PACKAGE( Expat )
 IF( NOT EXPAT_FOUND )
     # cmake introduced a bug in version 3.27
     FIND_PACKAGE( PkgConfig )


### PR DESCRIPTION
Expat added CMake scripts in 2.3.0 version. Configuring libwbxml with older Expat failed:

~~~~
    CMake Error at CMakeLists.txt:97 (FIND_PACKAGE):
      By not providing "FindExpat.cmake" in CMAKE_MODULE_PATH this project has
      asked CMake to find a package configuration file provided by "Expat", but
      CMake did not find one.

      Could not find a package configuration file provided by "Expat" with any of
      the following names:

	ExpatConfig.cmake
	expat-config.cmake

      Add the installation prefix of "Expat" to CMAKE_PREFIX_PATH or set
      "Expat_DIR" to a directory containing one of the above files.  If "Expat"
      provides a separate development package or SDK, be sure it has been
      installed.
~~~~

The cause was that FIND_PACKAGE() was incorrectly called with REQUIRED option. This patch fixes it.