### PR TITLE
Use GNUInstallDirs for defining installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,21 +55,13 @@ ENDIF( WBXML_INSTALL_FULL_HEADERS )
 # TODO: Move to external file/macro
 SET( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" )
 
-SET( LIB_SUFFIX "" CACHE STRING "The library directory suffix. 32bit empty string, 64 for 64bit." )
-SET( LIB_INSTALL_DIR  "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE INTERNAL "libary location" )
-SET( LIBDATA_INSTALL_DIR  "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The library data directory" )
-SET( BIN_INSTALL_DIR  "${CMAKE_INSTALL_PREFIX}/bin" CACHE INTERNAL "binary location" )
-SET( SHARE_INSTALL_DIR  "${CMAKE_INSTALL_PREFIX}/share" CACHE INTERNAL "data location" )
-SET( INCLUDE_INSTALL_DIR  "${CMAKE_INSTALL_PREFIX}/include" CACHE INTERNAL "headers location" )
-SET( LIBEXEC_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/libexec" CACHE INTERNAL "libexec location" )
-
 #MESSAGE(STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}" )
 
-SET( LIBWBXML_LIBRARIES_DIR "${LIB_INSTALL_DIR}" CACHE PATH "wbxml library location" )
-SET( LIBWBXML_INCLUDE_DIR "${INCLUDE_INSTALL_DIR}/libwbxml-${LIBWBXML_LIBVERSION_SOVERSION}.${LIBWBXML_LIBVERSION_AGE}" CACHE PATH "libwbxml headers location" )
-SET( LIBWBXML_BIN_DIR "${BIN_INSTALL_DIR}" CACHE PATH "wbxml binaries location" )
-SET( LIBWBXML_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH "wbxml data location" )
-SET( LIBWBXML_EXEC_INSTALL_DIR "${BIN_INSTALL_DIR}" CACHE PATH "wbxml binary location" )
+include(GNUInstallDirs)
+SET( LIBWBXML_LIBRARIES_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "wbxml library location" )
+SET( LIBWBXML_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/libwbxml-${LIBWBXML_LIBVERSION_SOVERSION}.${LIBWBXML_LIBVERSION_AGE}" CACHE PATH "libwbxml headers location" )
+SET( LIBWBXML_BIN_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "wbxml binaries location" )
+SET( LIBWBXML_EXEC_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "wbxml binary location" )
 
 # find header files and type size
 INCLUDE( CheckTypeSize )
@@ -233,7 +225,7 @@ IF( ENABLE_INSTALL_DOC )
 ENDIF( ENABLE_INSTALL_DOC )
 
 # todo: add requires in pc file
-INSTALL( FILES "${CMAKE_CURRENT_BINARY_DIR}/libwbxml2.pc" DESTINATION "${LIBDATA_INSTALL_DIR}/pkgconfig/" )
+INSTALL( FILES "${CMAKE_CURRENT_BINARY_DIR}/libwbxml2.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/" )
 # status output
 INCLUDE( ShowStatus )
 MESSAGE( STATUS "==================================================" )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Standard header and include paths were already defined.
 
 include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
 
 configure_package_config_file(
     libwbxml2-config.cmake.in

--- a/cmake/modules/AddDocumentation.cmake
+++ b/cmake/modules/AddDocumentation.cmake
@@ -10,9 +10,8 @@
 
 INCLUDE( Documentation )
 
-SET( SHARE_INSTALL_DIR    "${CMAKE_INSTALL_PREFIX}/share" CACHE INTERNAL "share location" )
-SET( DOC_MAN_INSTALL_DIR  "${SHARE_INSTALL_DIR}/man" CACHE INTERNAL "man page location" )
-SET( DOC_INSTALL_DIR      "${SHARE_INSTALL_DIR}/doc/${PROJECT_NAME}" CACHE INTERNAL "documentation location" )
+SET( DOC_MAN_INSTALL_DIR  "${CMAKE_INSTALL_MANDIR}" CACHE INTERNAL "man page location" )
+SET( DOC_INSTALL_DIR      "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}" CACHE INTERNAL "documentation location" )
 SET( DOC_TEXT_INSTALL_DIR "${DOC_INSTALL_DIR}" CACHE INTERNAL "text documentation location" )
 SET( DOC_HTML_INSTALL_DIR "${DOC_INSTALL_DIR}/html" CACHE INTERNAL "HTML documentation location" )
 

--- a/libwbxml2.pc.cmake
+++ b/libwbxml2.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@LIBWBXML_EXEC_INSTALL_DIR@
-libdir=@LIBWBXML_LIBRARIES_DIR@
-includedir=@LIBWBXML_INCLUDE_DIR@
+exec_prefix=${prefix}/@LIBWBXML_EXEC_INSTALL_DIR@
+libdir=${prefix}/@LIBWBXML_LIBRARIES_DIR@
+includedir=${prefix}/@LIBWBXML_INCLUDE_DIR@
 
 Name: libwbxml2
 Description: C wbxml library


### PR DESCRIPTION
LIB_SUFFIX and various *_INSTALL_DIR variables were never standardized by CMake and Fedora is going to stop defining them <https://fedoraproject.org/wiki/Changes/CMake_drop_install_vars>.

As a result the build script would install the libwbxml2 library into a wrong path (/usr/lib instead of /usr/lib64) on 64-bit systems.

Since libwbxml2 already uses GNUInstallDirs CMake module in cmake/CMakeLists.txt, it's easier to rely on its autodection of CMAKE_INSTALL_LIBDIR rather than deriving LIB_SUFFIX from CMAKE_INSTALL_LIBDIR.

This patch ports the build script to GNUInstallDirs. It significantly simplifies the script.

Resolve: https://bugzilla.redhat.com/show_bug.cgi?id=2381269